### PR TITLE
Update instruction text to be more explicit about string > int casting

### DIFF
--- a/notebooks/week_1.ipynb
+++ b/notebooks/week_1.ipynb
@@ -163,7 +163,7 @@
    "id": "e4b66e67-9bc0-4a4b-843a-b434c09f0a1e",
    "metadata": {},
    "source": [
-    "The last expression int(\"ab\") triggered what is called an **exception**. This means that the function <code>int()</code> received an \"exceptional\" input, which it cannot interpret as an integer. In such cases the default exception is \"ValueError\". In the cell below, try to convert a string to an integer without causing any exception!"
+    "The last expression int(\"ab\") triggered what is called an **exception**. This means that the function <code>int()</code> received an \"exceptional\" input, which it cannot interpret as an integer. In such cases the default exception is \"ValueError\". Some strings, ones that represent numbers, can be interpreted as an integer. In the cell below, try to convert a suitable string to an integer without causing any exception!"
    ]
   },
   {
@@ -698,7 +698,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In the first part of the exercises for the first week, there was some confusion about casting strings to integers. This adds some text specifying that only strings that represent numbers can be converted to integers.