### PR TITLE
wrap --version in code block

### DIFF
--- a/docs/week_3.md
+++ b/docs/week_3.md
@@ -26,7 +26,7 @@ For your projects, you will use Git which is a free and open source distributed 
 - Download the latest version and start the installer
 - Follow the Git Setup wizard
 - Open the windows command prompt (or Git Bash)
-- Type: git --version   (to verify git is installed)
+- Type: `git --version`   (to verify git is installed)
 
 ##### Mac
 
@@ -34,7 +34,7 @@ For your projects, you will use Git which is a free and open source distributed 
 - Download the latest version and start the installer
 - Follow the instructions
 - Open the command prompt "terminal"
-- Type: git --version   (to verify git is installed)
+- Type: `git --version`   (to verify git is installed)
 
 ##### Linux
 
@@ -63,19 +63,19 @@ Anaconda is a distribution of Python used for package management and deployment.
 
 - Follow the instructions of the following link: [Anaconda for Windows](https://docs.anaconda.com/anaconda/install/windows/)
 - Open anaconda prompt
-- Type: python --version  (to verify python is installed)
+- Type: `python --version`  (to verify python is installed)
 
 ##### Mac
 
 - Follow the instructions of the following link: [Anaconda for Mac](https://docs.anaconda.com/anaconda/install/mac-os/)
 - Open terminal
-- Type: python --version   (to verify python is installed)
+- Type: `python --version`   (to verify python is installed)
 
 ##### Linux
 
 - Follow the instructions of the following link: [Anaconda for Linux](https://docs.anaconda.com/anaconda/install/linux/)
 - Open terminal
-- Type: python --version  (to verify python is installed)
+- Type: `python --version`  (to verify python is installed)
 
 ### Tutorial
 


### PR DESCRIPTION
In the Jupyter book, the double dashes are rendered as one dash, which led to confusion during installing:
![Screenshot 2023-10-09 at 13-29-40 3  Visual Studio Code Git and Anaconda — BIO-210](https://github.com/EPFL-BIO-210/BIO-210-CourseMaterials/assets/18229293/811b446f-73c0-4aa6-aa12-152c64b054aa)

I wrapped all the commands in markdown code blocks to display it correctly.